### PR TITLE
hooking up the versions controller

### DIFF
--- a/app/controllers/book/versions_controller.rb
+++ b/app/controllers/book/versions_controller.rb
@@ -1,4 +1,19 @@
 class Book::VersionsController < MetaVersionController
+  def index
+    @versions_with_prompt_changes = @parent.versions.map do |version|
+      changes = parse_object_changes(version)
+      found = changes.any? { |property, (old_value, _new_value)| property == 'plot' && old_value }
+
+      next unless found
+
+      {
+        id: version.id,
+        updated_at: changes['updated_at']&.last,
+        old_plot: changes['plot']&.first
+      }
+    end.compact
+  end
+
   private
 
   def parent_class

--- a/app/views/book/versions/index.html.slim
+++ b/app/views/book/versions/index.html.slim
@@ -1,0 +1,23 @@
+=r ux.container
+  =r ux.row
+    =r ux.column width: 16
+      = turbo_frame_tag 'crud_frame', target: '_top'
+        =r ux.component_container
+          =r ux.component_header text: @version_header
+          =r ux.component_return_action text: '< Back', url: send(@parent_path, @parent), data: { 'turbo-action': 'replace'}
+        =r ux.component_divider
+        - @versions_with_prompt_changes.each do |version|
+          = r ux.version
+            =r ux.version_menu
+              =r ux.menu 'right'
+                =r ux.item
+                  = button_to 'Revert Version', send(@revert_path, id: version[:id]), method: :post, class: 'btn-primary', data: { 'turbo-action': 'replace'}
+                =r ux.item
+                  = button_to 'Merge With Current', send(@merge_path, id: version[:id]), method: :post, class: 'btn-secondary', data: { 'turbo-action': 'replace' }
+            =r ux.version_meta
+              =r ux.component_container
+                = r ux.version_meta_text text: "Version ID: #{version[:id]}"
+                = r ux.version_meta_text text: "Changed: #{version[:updated_at].strftime('%m/%d/%Y')}"
+            =r ux.version_content
+              =r ux.segment '!bg-yellow-100 !mb-10'
+                = markdown version[:old_plot] 


### PR DESCRIPTION
<div id='description'>
<h3>Summary by Bito</h3>
This pull request introduces a new versions controller with an index method for retrieving versions and a view for displaying them. Users can now revert or merge changes, enhancing version management functionality.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and well-defined, requiring minimal effort to understand and review.
</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new version history display that highlights modifications made to key content.
  - The interface now presents version details including identifiers, update dates, and a preview of previous content.
  - Added quick action buttons allowing users to revert or merge changes seamlessly, all within a dynamically updating view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->