### PR TITLE
Refactor Book model: Add Chapters association and rename chapters attribute

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -35,7 +35,7 @@ class BooksController < MetaController
       :narrative_structure_id,
       :moral,
       :plot,
-      :chapters,
+      :chapter_count,
       :pages,
       :protagonist_id,
       antagonist_ids: [],

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -10,7 +10,7 @@
 #  perspective_id         :bigint
 #  moral                  :text
 #  plot                   :text
-#  chapters               :integer
+#  chapter_count          :integer
 #  pages                  :integer
 #  narrative_structure_id :bigint
 #  protagonist_id         :bigint
@@ -24,11 +24,12 @@ class Book < ApplicationRecord
   has_many :book_antagonists, dependent: :destroy
   has_many :antagonists, through: :book_antagonists, source: :character
   has_and_belongs_to_many :characters
+  has_many :chapters, dependent: :destroy
 
   validates :title, presence: true
   validate :character_role_uniqueness
 
-  has_paper_trail ignore: %i[title moral chapters pages], versions: {
+  has_paper_trail ignore: %i[title moral chapter_count pages], versions: {
     scope: -> { order('id desc') }
   }
 

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: chapters
+#
+#  id         :bigint           not null, primary key
+#  number     :integer          not null
+#  summary    :text            not null
+#  content    :text            not null
+#  book_id    :bigint          not null
+#  created_at :datetime        not null
+#  updated_at :datetime        not null
+#
+class Chapter < ApplicationRecord
+  belongs_to :book
+
+  validates :number, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :summary, presence: true
+  validates :content, presence: true
+  validates :number, uniqueness: { scope: :book_id, message: "should be unique within the book" }
+end

--- a/app/views/books/_form.html.slim
+++ b/app/views/books/_form.html.slim
@@ -36,8 +36,8 @@
         { multiple: true, class: "ui fluid dropdown" }
 
     =r ux.component_field
-      = form.label :chapters
-      = form.number_field :chapters, value: @component.chapters
+      = form.label :chapter_count, "Chapter Count"
+      = form.number_field :chapter_count, value: @component.chapter_count
 
     =r ux.component_field
       = form.label :pages

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -23,8 +23,8 @@
                 =r ux.h5 text: 'Narrative Structure'
                 = @component.narrative_structure.name
 
-                =r ux.h5 text: 'Chapters'
-                = @component.chapters
+                =r ux.h5 text: 'Chapter Count'
+                = @component.chapter_count
 
                 =r ux.h5 text: 'Pages'
                 = @component.pages

--- a/db/migrate/20250222195730_rename_chapters_to_chapter_count_in_books.rb
+++ b/db/migrate/20250222195730_rename_chapters_to_chapter_count_in_books.rb
@@ -1,0 +1,5 @@
+class RenameChaptersToChapterCountInBooks < ActiveRecord::Migration[7.2]
+  def change
+    rename_column :books, :chapters, :chapter_count
+  end
+end

--- a/db/migrate/20250222195751_create_chapters.rb
+++ b/db/migrate/20250222195751_create_chapters.rb
@@ -1,0 +1,14 @@
+class CreateChapters < ActiveRecord::Migration[7.2]
+  def change
+    create_table :chapters do |t|
+      t.integer :number, null: false
+      t.text :summary, null: false
+      t.text :content, null: false
+      t.references :book, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :chapters, [:book_id, :number], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_22_180922) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_22_195751) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -49,7 +49,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_22_180922) do
     t.bigint "perspective_id"
     t.text "moral"
     t.text "plot"
-    t.integer "chapters"
+    t.integer "chapter_count"
     t.integer "pages"
     t.bigint "narrative_structure_id"
     t.bigint "protagonist_id"
@@ -65,6 +65,17 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_22_180922) do
     t.bigint "character_id", null: false
     t.index ["book_id", "character_id"], name: "index_books_characters_on_book_id_and_character_id"
     t.index ["character_id", "book_id"], name: "index_books_characters_on_character_id_and_book_id"
+  end
+
+  create_table "chapters", force: :cascade do |t|
+    t.integer "number", null: false
+    t.text "summary", null: false
+    t.text "content", null: false
+    t.bigint "book_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["book_id", "number"], name: "index_chapters_on_book_id_and_number", unique: true
+    t.index ["book_id"], name: "index_chapters_on_book_id"
   end
 
   create_table "character_types", force: :cascade do |t|
@@ -265,6 +276,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_22_180922) do
   add_foreign_key "books", "narrative_structures"
   add_foreign_key "books", "perspectives"
   add_foreign_key "books", "writing_styles"
+  add_foreign_key "chapters", "books"
   add_foreign_key "locations", "regions"
   add_foreign_key "texts", "writing_styles"
 end

--- a/spec/factories/books.rb
+++ b/spec/factories/books.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     title { Faker::Book.title }
     moral { Faker::Lorem.paragraph }
     plot { Faker::Lorem.paragraphs(number: 3).join("\n\n") }
-    chapters { rand(5..50) }
+    chapter_count { rand(5..50) }
     pages { rand(100..1000) }
 
     association :writing_style

--- a/spec/factories/chapters.rb
+++ b/spec/factories/chapters.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :chapter do
+    number { rand(1..100) }
+    summary { Faker::Lorem.paragraph }
+    content { Faker::Lorem.paragraphs(number: 5).join("\n\n") }
+    association :book
+
+    trait :sequential do
+      sequence(:number) { |n| n }
+    end
+  end
+end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Book, type: :model do
     it { should have_many(:book_antagonists) }
     it { should have_many(:antagonists).through(:book_antagonists) }
     it { should have_and_belong_to_many(:characters) }
+    it { should have_many(:chapters).dependent(:destroy) }
   end
 
   describe 'factory' do
@@ -33,6 +34,13 @@ RSpec.describe Book, type: :model do
     it 'can be created with characters' do
       book = create(:book, :with_characters)
       expect(book.characters).to be_present
+    end
+
+    it 'can be created with chapters' do
+      book = create(:book)
+      create_list(:chapter, 3, :sequential, book: book)
+      expect(book.chapters.count).to eq(3)
+      expect(book.chapters.map(&:number)).to eq([1, 2, 3])
     end
 
     it 'can be created as complete' do

--- a/spec/models/chapter_spec.rb
+++ b/spec/models/chapter_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Chapter, type: :model do
+  describe 'validations' do
+    it { should validate_presence_of(:number) }
+    it { should validate_presence_of(:summary) }
+    it { should validate_presence_of(:content) }
+    it { should validate_numericality_of(:number).only_integer.is_greater_than(0) }
+
+    describe 'uniqueness' do
+      subject { create(:chapter) }
+      it { should validate_uniqueness_of(:number).scoped_to(:book_id).with_message("should be unique within the book") }
+    end
+  end
+
+  describe 'associations' do
+    it { should belong_to(:book) }
+  end
+
+  describe 'factory' do
+    it 'has a valid factory' do
+      expect(build(:chapter)).to be_valid
+    end
+
+    it 'can create sequential chapters' do
+      book = create(:book)
+      chapters = create_list(:chapter, 3, :sequential, book: book)
+      numbers = chapters.map(&:number)
+      expect(numbers).to eq(numbers.sort)
+      expect(numbers.uniq).to eq(numbers)
+    end
+  end
+end


### PR DESCRIPTION
- Renamed 'chapters' to 'chapter_count' in Book model and related files
- Added has_many :chapters association to Book model
- Updated schema, views, controller, and specs to reflect the change
- Added unique index for chapters by book and number 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request refactors the Book model by renaming the 'chapters' attribute to 'chapter_count' and establishes a has_many association with the Chapter model. It updates the controller, views, and schema accordingly, and includes new migrations and tests for the Chapter model.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>