### PR TITLE
Improving UX hiding the plot and render buttons during generation

### DIFF
--- a/app/jobs/render_book_job.rb
+++ b/app/jobs/render_book_job.rb
@@ -15,20 +15,35 @@ class RenderBookJob < ApplicationJob
 
   def start_rendering
     @book.update(rendering: true)
-    broadcast_book_update
+    broadcast_updates
   end
 
   def finish_rendering
     @book.update(rendering: false)
-    broadcast_book_update
+    broadcast_updates
   end
 
-  def broadcast_book_update
+  def broadcast_updates
+    broadcast_view_button_update
+    broadcast_action_buttons_update
+  end
+
+  def broadcast_view_button_update
     computer_name = @book.class.name.underscore
     Turbo::StreamsChannel.broadcast_update_to(
       "#{computer_name}_#{@book.id}",
       target: "book_#{@book.id}_view_button",
       partial: "books/view_book_button",
+      locals: { component: @book }
+    )
+  end
+
+  def broadcast_action_buttons_update
+    computer_name = @book.class.name.underscore
+    Turbo::StreamsChannel.broadcast_update_to(
+      "#{computer_name}_#{@book.id}",
+      target: "book_#{@book.id}_action_buttons",
+      partial: "books/action_buttons",
       locals: { component: @book }
     )
   end

--- a/app/jobs/render_book_job.rb
+++ b/app/jobs/render_book_job.rb
@@ -15,27 +15,12 @@ class RenderBookJob < ApplicationJob
 
   def start_rendering
     @book.update(rendering: true)
-    broadcast_updates
+    broadcast_action_buttons_update
   end
 
   def finish_rendering
     @book.update(rendering: false)
-    broadcast_updates
-  end
-
-  def broadcast_updates
-    broadcast_view_button_update
     broadcast_action_buttons_update
-  end
-
-  def broadcast_view_button_update
-    computer_name = @book.class.name.underscore
-    Turbo::StreamsChannel.broadcast_update_to(
-      "#{computer_name}_#{@book.id}",
-      target: "book_#{@book.id}_view_button",
-      partial: "books/view_book_button",
-      locals: { component: @book }
-    )
   end
 
   def broadcast_action_buttons_update

--- a/app/views/books/_action_buttons.html.slim
+++ b/app/views/books/_action_buttons.html.slim
@@ -1,0 +1,6 @@
+= turbo_frame_tag "book_#{component.id}_action_buttons"
+  =r ux.component_button_holder
+    - unless component.pending || component.rendering
+      = link_to 'Edit', edit_book_path(component), class: 'btn-edit mr-2 !pb-1.5', data: { turbo_frame: '_top' }
+      = button_to 'Generate Plot', generate_prompt_book_path(component), method: :post, class: 'btn-primary mr-2', data: { 'turbo-action': 'replace'}
+      = button_to 'Render Book', render_book_book_path(component), method: :post, class: 'btn-render', data: { 'turbo-action': 'replace'} 

--- a/app/views/books/_action_buttons.html.slim
+++ b/app/views/books/_action_buttons.html.slim
@@ -1,6 +1,12 @@
 = turbo_frame_tag "book_#{component.id}_action_buttons"
   =r ux.component_button_holder
-    - unless component.pending || component.rendering
+    - if component.rendering
+      .text-gray-600.italic Rendering book in progress...
+    - elsif component.pending
+      .text-gray-600.italic Generating plot...
+    - else
       = link_to 'Edit', edit_book_path(component), class: 'btn-edit mr-2 !pb-1.5', data: { turbo_frame: '_top' }
       = button_to 'Generate Plot', generate_prompt_book_path(component), method: :post, class: 'btn-primary mr-2', data: { 'turbo-action': 'replace'}
-      = button_to 'Render Book', render_book_book_path(component), method: :post, class: 'btn-render', data: { 'turbo-action': 'replace'} 
+      = button_to 'Render Book', render_book_book_path(component), method: :post, class: 'btn-render mr-2', data: { 'turbo-action': 'replace'}
+      - if component.chapters.any?
+        = link_to 'View Book', read_book_path(component), class: 'btn-primary', data: { turbo_frame: '_top' } 

--- a/app/views/books/_view_book_button.html.slim
+++ b/app/views/books/_view_book_button.html.slim
@@ -1,7 +1,0 @@
-= turbo_frame_tag "book_#{component.id}_view_button"
-  - if component.chapters.any?
-    =r ux.segment 'mt-4'
-      - if component.rendering
-        .text-gray-600.italic Rendering book in progress...
-      - else
-        = link_to 'View Full Book', read_book_path(component), class: 'btn-primary fluid', data: { turbo_frame: "_top" } 

--- a/app/views/books/iterate.turbo_stream.erb
+++ b/app/views/books/iterate.turbo_stream.erb
@@ -4,4 +4,8 @@
 
 <%= turbo_stream.replace "#{@computer_name}_form" do %>
   <%= render partial: 'iterate_form', locals: { component: @component, computer_name: @computer_name} %>
+<% end %>
+
+<%= turbo_stream.replace "book_#{@component.id}_action_buttons" do %>
+  <%= render partial: 'action_buttons', locals: { component: @component } %>
 <% end %> 

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -7,9 +7,7 @@
             = breadcrumb_parent @component_name, send(@component_list_path)
             = @component.title
           =r ux.component_button_holder
-            = link_to 'Edit', send(@component_edit_path, @component), class: 'btn-edit mr-2 !pb-1.5'
-            = button_to 'Generate Plot', send(@component_generate_prompt_path), method: :post, class: 'btn-primary mr-2', data: { 'turbo-action': 'replace'}
-            = button_to 'Render Book', render_book_book_path(@component), method: :post, class: 'btn-render', data: { 'turbo-action': 'replace'}
+            = render partial: 'action_buttons', locals: { component: @component }
         =r ux.component_divider
 
         =r ux.grid

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -5,7 +5,7 @@
         =r ux.component_container
           =r ux.component_header
             = breadcrumb_parent @component_name, send(@component_list_path)
-            = @component.title
+            = truncate(@component.title, length: 30)
           =r ux.component_button_holder
             = render partial: 'action_buttons', locals: { component: @component }
         =r ux.component_divider
@@ -56,8 +56,6 @@
                         = link_to character.name, character_path(character), class: 'text-blue-700'
                 - else
                   | None assigned
-
-              = render partial: 'view_book_button', locals: { component: @component }
 
         =r ux.segment '!mb-10'
           =r ux.h5 text: 'Moral'


### PR DESCRIPTION
<div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances the user experience by updating action buttons for book generation and rendering. It introduces new methods for broadcasting these buttons and improves the UI by truncating long book titles and removing outdated elements.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic, state-driven action buttons on book pages that let users edit, generate plots, render books, and—when applicable—view full book details. These buttons update in real time according to each book’s status.

- **Refactor**
  - Streamlined the interface by consolidating various action controls into a single, unified layout with cleaner title displays for improved readability and overall responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->